### PR TITLE
TRIVIAL: add missing docker/.config file

### DIFF
--- a/docker/.config
+++ b/docker/.config
@@ -1,0 +1,1 @@
+IMAGE_NAME=frontend-node-8.9.4-yarn-1.3.2


### PR DESCRIPTION
It is not possible to release the library from CIng without it.